### PR TITLE
feat: HTTP-Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Below example shows an excerpt from [@stichting-crow/imbor](https://github.com/s
 There is a single (developer-local) endpoint used, that gets the defined prefixes set.
 Then, a MS-Access database is imported into the GraphDB-instance,
 five `INSERT {} WHERE {}`-SPARQL update requests are sent.
-After a short delay (default: 5 sec), two graphs are downloaded.
 
 ```yaml
 version: v5

--- a/docs/index.md
+++ b/docs/index.md
@@ -323,6 +323,20 @@ steps:
 
 Implemented by Comunica.
 
+## Execute web requests with `http-request`
+
+Run any GET, POST, etc. HTTP requests.
+
+| Configure                   | Notes                                |
+| --------------------------- | ------------------------------------ |
+| `http-request:`             | Path to a web resource               |
+| `with:`                     |
+| &nbsp;&nbsp; `destination:` | Save response to local file          |
+| &nbsp;&nbsp; `body:`        | Request body (string)                |
+| &nbsp;&nbsp; `body-file:`   | Request body (file contents)         |
+| &nbsp;&nbsp; `method:`      | Request HTTP method (GET, POST, ...) |
+| &nbsp;&nbsp; `headers:`     | Other request headers (Dictionary)   |
+
 # Targets
 
 ## Export a job dataset to a local file with `file`

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -3,19 +3,20 @@
 The following table indicates for any module if it can be used as Source, Step or Target.
 And if so, which arguments may be supplied.
 
-| Module type            | Source | Step | Target | `credentials` | `into-graph`  | `only-graphs` | Other       |
-| :--------------------- | :----: | :--: | :----: | :-----------: | :-----------: | :-----------: | :---------- |
-| sparql                 |   \*   |      |   \*   |      \*       |               |               | Source-Type |
+| Module type            | Source | Step | Target | `credentials` | `into-graph`  | `only-graphs` | Other                                         |
+| :--------------------- | :----: | :--: | :----: | :-----------: | :-----------: | :-----------: | :-------------------------------------------- |
+| sparql                 |   \*   |      |   \*   |      \*       |               |               | Source-Type                                   |
 | sparql-update-endpoint |        |      |   \*   |      \*       |
 | file                   |   \*   |      |   \*   |               |      \*       |      \*       |
 | laces-hub              |   \*   |      |   \*   |    always     |  when Source  |  when Target  |
 | triplydb               |   \*   |      |   \*   |    always     |      \*       |      \*       |
 | construct              |        |  \*  |        |               |      \*       |
 | update                 |        |  \*  |
-| assert                 |        |  \*  |        |               |               |               | Message     |
+| assert                 |        |  \*  |        |               |               |               | Message                                       |
 | shell                  |        |  \*  |
+| http-request           |        |  \*  |        |               |               |               | Body, Body-File, Destination, Method, Headers |
 | shacl                  |        |  \*  |        |               |               |      \*       |
-| infer                  |        |  \*  |        |               | Results-Graph |      \*       | Ruleset     |
+| infer                  |        |  \*  |        |               | Results-Graph |      \*       | Ruleset                                       |
 | sparql-graph-store     |        |      |   \*   |      \*       |      \*       |      \*       |
 | sparql-quad-store      |        |      |   \*   |      \*       |      \*       |      \*       |
 

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -9,17 +9,17 @@
       "pattern": "^v5",
       "description": "Version of the sparql-query-runner configuration"
     },
-    "jobs": { "$ref": "#/$defs/JobsObject" },
-    "prefixes": { "$ref": "#/$defs/PrefixesObject" },
+    "jobs": { "$ref": "#/definitions/JobsObject" },
+    "prefixes": { "$ref": "#/definitions/PrefixesObject" },
     "$schema": {
       "type": "string",
       "const": "https://rdmr.eu/sparql-query-runner/schema.json"
     }
   },
-  "$defs": {
+  "definitions": {
     "PrefixesObject": {
-      "description": "Prefixes used in the SPARQL queries and CONSTRUCT result files.",
       "type": "object",
+      "title": "Prefixes used in the SPARQL queries and result files.",
       "patternProperties": {
         "^[a-zA-Z0-9-_]+$": {
           "type": "string",
@@ -34,30 +34,30 @@
       "title": "Final targets",
       "description": "A workflow run is made up of one or more jobs, that run consecutively by default.",
       "patternProperties": {
-        "^[a-z][a-z0-9-_]{0,127}$": { "$ref": "#/$defs/Job" }
+        "^[a-z][a-z0-9-_]{0,127}$": { "$ref": "#/definitions/Job" }
       },
       "additionalProperties": false
     },
 
     "Job": {
-      "description": "The title of a job.",
       "type": "object",
+      "title": "A workflow job that is executed top-down",
       "properties": {
         "prefixes": {
-          "$ref": "#/$defs/PrefixesObject",
-          "description": "Prefixes specific to this job"
+          "$ref": "#/definitions/PrefixesObject",
+          "title": "Prefixes specific to this job"
         },
         "sources": {
           "type": "array",
-          "items": { "$ref": "#/$defs/JobSource" }
+          "items": { "$ref": "#/definitions/JobSource" }
         },
         "steps": {
           "type": "array",
-          "items": { "$ref": "#/$defs/JobStep" }
+          "items": { "$ref": "#/definitions/JobStep" }
         },
         "targets": {
           "type": "array",
-          "items": { "$ref": "#/$defs/JobTarget" }
+          "items": { "$ref": "#/definitions/JobTarget" }
         },
         "independent": {
           "description": "Indicate that the job does not depend on a preceding job",
@@ -68,89 +68,48 @@
     },
 
     "JobSource": {
-      "type": "object",
       "title": "RDF data sources",
-      "properties": {
-        "file": { "$ref": "#/$defs/Parts/Source/File" },
-        "sparql": { "$ref": "#/$defs/Parts/Source/Sparql" },
-        "laces-hub": { "$ref": "#/$defs/Parts/Source/LacesHub" },
-        "triplydb": { "$ref": "#/$defs/Parts/Source/Triplydb" },
-        "with": {
-          "type": "object",
-          "description": "Optional arguments to access or to import data from the source.",
-          "properties": {
-            "credentials": { "$ref": "#/$defs/Options/Credentials" },
-            "only-graphs": { "$ref": "#/$defs/Options/OnlyGraphs" },
-            "into-graph": { "$ref": "#/$defs/Options/IntoGraph" }
-          }
-        }
-      },
       "oneOf": [
-        { "required": ["file"] },
-        { "required": ["sparql"] },
-        { "required": ["laces-hub"] },
-        { "required": ["triplydb"] }
+        { "$ref": "#/definitions/Parts/Source/File" },
+        { "$ref": "#/definitions/Parts/Source/Sparql" },
+        { "$ref": "#/definitions/Parts/Source/LacesHub" },
+        { "$ref": "#/definitions/Parts/Source/Triplydb" }
       ]
     },
     "JobStep": {
-      "type": "object",
       "title": "Intermediate job steps",
-      "properties": {
-        "construct": { "$ref": "#/$defs/Parts/Step/Construct" },
-        "update": { "$ref": "#/$defs/Parts/Step/Update" },
-        "assert": { "$ref": "#/$defs/Parts/Step/Assert" },
-        "shell": { "$ref": "#/$defs/Parts/Step/Shell" },
-        "shacl": { "$ref": "#/$defs/Parts/Step/Shacl" },
-        "infer": { "$ref": "#/$defs/Parts/Step/Infer" },
-        "with": {
-          "type": "object",
-          "description": "Optional arguments to modify data from this step.",
-          "properties": {
-            "only-graphs": { "$ref": "#/$defs/Options/OnlyGraphs" },
-            "into-graph": { "$ref": "#/$defs/Options/IntoGraph" }
-          }
-        }
-      },
       "oneOf": [
-        { "required": ["construct"] },
-        { "required": ["update"] },
-        { "required": ["assert"] },
-        { "required": ["shell"] },
-        { "required": ["shacl"] },
-        { "required": ["infer"] }
+        { "$ref": "#/definitions/Parts/Step/Construct" },
+        { "$ref": "#/definitions/Parts/Step/Update" },
+        { "$ref": "#/definitions/Parts/Step/Assert" },
+        { "$ref": "#/definitions/Parts/Step/Shell" },
+        { "$ref": "#/definitions/Parts/Step/Shacl" },
+        { "$ref": "#/definitions/Parts/Step/Infer" },
+        { "$ref": "#/definitions/Parts/Step/HttpRequest" }
       ]
     },
     "JobTarget": {
-      "type": "object",
-      "properties": {
-        "file": { "$ref": "#/$defs/Parts/Target/File" },
-        "sparql-update-endpoint": { "$ref": "#/$defs/Parts/Target/SparqlUpdateEndpoint" },
-        "sparql-graph-store": { "$ref": "#/$defs/Parts/Target/SparqlGraphStore" },
-        "sparql-quad-store": { "$ref": "#/$defs/Parts/Target/SparqlQuadStore" },
-        "laces-hub": { "$ref": "#/$defs/Parts/Target/LacesHub" },
-        "triplydb": { "$ref": "#/$defs/Parts/Target/Triplydb" },
-        "with": {
-          "type": "object",
-          "description": "Optional arguments to export data to this target.",
-          "properties": {
-            "credentials": { "$ref": "#/$defs/Options/Credentials" },
-            "only-graphs": { "$ref": "#/$defs/Options/OnlyGraphs" },
-            "into-graph": { "$ref": "#/$defs/Options/IntoGraph" }
-          }
-        }
-      },
+      "title": "Export in-mem results",
       "oneOf": [
-        { "required": ["file"] },
-        { "required": ["sparql-update-endpoint"] },
-        { "required": ["sparql-graph-store"] },
-        { "required": ["sparql-quad-store"] },
-        { "required": ["laces-hub"] },
-        { "required": ["triplydb"] }
+        { "$ref": "#/definitions/Parts/Target/File" },
+        { "$ref": "#/definitions/Parts/Target/SparqlUpdateEndpoint" },
+        { "$ref": "#/definitions/Parts/Target/SparqlGraphStore" },
+        { "$ref": "#/definitions/Parts/Target/SparqlQuadStore" },
+        { "$ref": "#/definitions/Parts/Target/LacesHub" },
+        { "$ref": "#/definitions/Parts/Target/Triplydb" }
       ]
     },
 
     "Options": {
+      "WithIntoGraph": {
+        "type": "object",
+        "properties": { "into-graph": { "$ref": "#/definitions/Options/WithIntoGraph" } }
+      },
       "IntoGraph": { "type": "string", "description": "(Option) Override the quads' graph." },
+      "WithOnlyGraphs": {
+        "type": "object",
+        "properties": { "only-graph": { "$ref": "#/definitions/Options/WithOnlyGraphs" } }
+      },
       "OnlyGraphs": {
         "type": "array",
         "items": { "type": "string" },
@@ -194,8 +153,12 @@
           }
         }
       },
+      "WithCredentials": {
+        "type": "object",
+        "properties": { "credentials": { "$ref": "#/definitions/Options/Credentials" } }
+      },
       "Credentials": {
-        "description": "(Optional) Method of authentication",
+        "title": "(Optional) Authentication",
         "type": "object",
         "properties": {
           "type": {
@@ -204,53 +167,302 @@
           }
         },
         "oneOf": [
-          { "$ref": "#/$defs/Options/CredentialsBasic" },
-          { "$ref": "#/$defs/Options/CredentialsBearer" },
-          { "$ref": "#/$defs/Options/CredentialsAnyHeader" }
+          { "$ref": "#/definitions/Options/CredentialsBasic" },
+          { "$ref": "#/definitions/Options/CredentialsBearer" },
+          { "$ref": "#/definitions/Options/CredentialsAnyHeader" }
         ]
+      },
+      "WithSourceType": {
+        "type": "object",
+        "properties": { "source-type": { "$ref": "#/definitions/Options/SourceType" } }
+      },
+      "SourceType": {
+        "type": "string",
+        "description": "(Optional) Instruct Comunica type of source"
       }
     },
 
     "Parts": {
       "Source": {
-        "File": { "type": "string", "description": "Path or URL to a RDF file" },
-        "LacesHub": { "type": "string", "description": "URL to a Laces dataset" },
-        "Sparql": { "type": "string", "description": "URL to a SPARQL endpoint" },
-        "Triplydb": { "type": "string", "description": "URL to a TriplyDB dataset" }
+        "File": {
+          "type": "object",
+          "title": "Local or remote RDF file",
+          "required": ["file"],
+          "properties": {
+            "file": { "type": "string", "description": "Path or URL to RDF file" },
+            "with": {
+              "anyOf": [
+                { "$ref": "#/definitions/Options/WithCredentials" },
+                { "$ref": "#/definitions/Options/WithOnlyGraphs" },
+                { "$ref": "#/definitions/Options/WithIntoGraph" }
+              ]
+            }
+          }
+        },
+        "LacesHub": {
+          "type": "object",
+          "title": "Laces Hub dataset",
+          "required": ["laces-hub"],
+          "properties": {
+            "laces-hub": { "type": "string", "description": "URL to Laces dataset" },
+            "with": {
+              "anyOf": [
+                { "$ref": "#/definitions/Options/WithCredentials" },
+                { "$ref": "#/definitions/Options/WithOnlyGraphs" },
+                { "$ref": "#/definitions/Options/WithIntoGraph" }
+              ]
+            }
+          }
+        },
+        "Sparql": {
+          "type": "object",
+          "title": "SPARQL endpoint",
+          "required": ["sparql"],
+          "properties": {
+            "sparql": { "type": "string", "description": "URL to SPARQL endpoint" },
+            "with": {
+              "anyOf": [
+                { "$ref": "#/definitions/Options/WithCredentials" },
+                { "$ref": "#/definitions/Options/WithSourceType" }
+              ]
+            }
+          }
+        },
+        "Triplydb": {
+          "type": "object",
+          "title": "TriplyDB dataset",
+          "required": ["triplydb"],
+          "properties": {
+            "triplydb": { "type": "string", "description": "URL to TriplyDB dataset" },
+            "with": {
+              "anyOf": [{ "$ref": "#/definitions/Options/WithCredentials" }]
+            }
+          }
+        }
       },
       "Step": {
         "Construct": {
-          "type": "string",
-          "description": "A SPARQL Construct query or path or URL to a .rq file"
+          "type": "object",
+          "title": "SPARQL Construct query",
+          "required": ["construct"],
+          "properties": {
+            "construct": { "type": "string", "description": "Query or path to .rq file" },
+            "with": {
+              "anyOf": [
+                { "$ref": "#/definitions/Options/WithCredentials" },
+                { "$ref": "#/definitions/Options/WithOnlyGraphs" },
+                { "$ref": "#/definitions/Options/WithIntoGraph" }
+              ]
+            }
+          }
         },
         "Shacl": {
-          "type": "string",
-          "description": "Path or URL to an RDF file containing SHACL shapes to validate the in-mem dataset with"
+          "type": "object",
+          "title": "Validate in-mem dataset with SHACL",
+          "required": ["shacl"],
+          "properties": {
+            "shacl": {
+              "type": "string",
+              "description": "Path or URL to an RDF file containing SHACL shapes"
+            },
+            "with": {
+              "type": "object",
+              "properties": {
+                "anyOf": [{ "$ref": "#/definitions/Options/WithOnlyGraphs" }]
+              }
+            }
+          }
         },
-        "Shell": { "type": "string", "description": "Perform any CLI / Shell script" },
+        "Shell": {
+          "type": "object",
+          "title": "Execute CLI (shell) script",
+          "required": ["shell"],
+          "properties": {
+            "shell": {
+              "type": "string",
+              "description": "CLI / Shell command"
+            },
+            "with": { "type": "object", "properties": {}, "additionalProperties": false }
+          }
+        },
         "Assert": {
-          "type": "string",
-          "description": "A SPARQL ASK query or path to a .rq file"
+          "type": "object",
+          "title": "SPARQL ASK query",
+          "required": ["assert"],
+          "properties": {
+            "assert": { "type": "string", "description": "Query or path to .rq file" },
+            "with": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "description": "Message to log if assertion not met"
+                }
+              }
+            }
+          }
         },
         "Update": {
-          "type": "string",
-          "description": "A SPARQL Update query or path or URL to a .ru file"
+          "type": "object",
+          "title": "SPARQL Update (DELETE, INSERT, ...)",
+          "required": ["update"],
+          "properties": {
+            "update": { "type": "string", "description": "Query or path to .ru file" },
+            "with": { "type": "object", "properties": {}, "additionalProperties": false }
+          }
         },
         "Infer": {
-          "type": "string",
-          "description": "Infer new statements with RDFS or OWL2RL reasoning"
+          "type": "object",
+          "title": "Infer new statements with RDFS or OWL2RL reasoning",
+          "required": ["infer"],
+          "properties": {
+            "infer": {
+              "type": "string",
+              "description": "(Optional) Path to RDF file with additional RDF facts"
+            },
+            "with": {
+              "type": "object",
+              "properties": {
+                "ruleset": {
+                  "type": "string",
+                  "enum": ["owl2rl", "rdfs"]
+                }
+              }
+            }
+          }
+        },
+        "HttpRequest": {
+          "type": "object",
+          "title": "Execute any HTTP request",
+          "required": ["http-request"],
+          "properties": {
+            "http-request": {
+              "type": "string",
+              "description": "URL to connect to"
+            },
+            "with": {
+              "type": "object",
+              "properties": {
+                "destination": {
+                  "type": "string",
+                  "description": "Path to save request output to"
+                },
+                "body": {
+                  "type": "string",
+                  "description": "Contents of request body"
+                },
+                "body-file": {
+                  "type": "string",
+                  "description": "Path to file with contents of request body"
+                },
+                "method": {
+                  "type": "string",
+                  "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+                },
+                "headers": {
+                  "type": "object"
+                }
+              }
+            }
+          }
         }
       },
       "Target": {
-        "File": { "type": "string", "description": "Path or URL to a save a RDF file to" },
-        "LacesHub": { "type": "string", "description": "URL to a Laces dataset to replace" },
-        "SparqlGraphStore": { "type": "string", "description": "URL to a SPARQL Graph Store" },
-        "SparqlQuadStore": { "type": "string", "description": "URL to a SPARQL Quad Store" },
-        "SparqlUpdateEndpoint": {
-          "type": "string",
-          "description": "URL to a SPARQL Update endpoint seperate from all sources"
+        "File": {
+          "type": "object",
+          "title": "Export to RDF file",
+          "required": ["file"],
+          "properties": {
+            "file": { "type": "string", "description": "Path or URL" },
+            "with": {
+              "anyOf": [
+                { "$ref": "#/definitions/Options/WithOnlyGraphs" },
+                { "$ref": "#/definitions/Options/WithIntoGraph" }
+              ]
+            }
+          }
         },
-        "Triplydb": { "type": "string", "description": "URL to a TriplyDB dataset" }
+        "LacesHub": {
+          "type": "object",
+          "title": "Laces Hub",
+          "required": ["sparql-update-endpoint"],
+          "properties": {
+            "sparql-update-endpoint": {
+              "type": "string",
+              "description": "URL to a Laces dataset to replace"
+            },
+            "with": {
+              "anyOf": [
+                { "$ref": "#/definitions/Options/WithCredentials" },
+                { "$ref": "#/definitions/Options/WithOnlyGraphs" },
+                { "$ref": "#/definitions/Options/WithIntoGraph" }
+              ]
+            }
+          }
+        },
+        "SparqlGraphStore": {
+          "type": "object",
+          "title": "SPARQL Graph Store",
+          "required": ["sparql-graph-store"],
+          "properties": {
+            "sparql-graph-store": {
+              "type": "string",
+              "description": "URL to a SPARQL Graph Store endpoint"
+            },
+            "with": {
+              "anyOf": [
+                { "$ref": "#/definitions/Options/WithCredentials" },
+                { "$ref": "#/definitions/Options/WithOnlyGraphs" },
+                { "$ref": "#/definitions/Options/WithIntoGraph" }
+              ]
+            }
+          }
+        },
+        "SparqlQuadStore": {
+          "type": "object",
+          "title": "SPARQL Quad Store",
+          "required": ["sparql-quad-store"],
+          "properties": {
+            "sparql-quad-store": {
+              "type": "string",
+              "description": "URL to a SPARQL Quad Store endpoint"
+            },
+            "with": {
+              "anyOf": [
+                { "$ref": "#/definitions/Options/WithCredentials" },
+                { "$ref": "#/definitions/Options/WithOnlyGraphs" },
+                { "$ref": "#/definitions/Options/WithIntoGraph" }
+              ]
+            }
+          }
+        },
+        "SparqlUpdateEndpoint": {
+          "type": "object",
+          "title": "Set one SPARQL Update endpoint to send SPARQL Updates to",
+          "required": ["laces-hub"],
+          "properties": {
+            "laces-hub": {
+              "type": "string",
+              "description": "URL to a SPARQL Update endpoint"
+            },
+            "with": { "type": "object", "properties": {}, "additionalProperties": false }
+          }
+        },
+        "Triplydb": {
+          "type": "object",
+          "title": "Replace a TriplyDB dataset",
+          "required": ["triplydb"],
+          "properties": {
+            "triplydb": { "type": "string", "description": "URL to a TriplyDB dataset" },
+            "with": {
+              "anyOf": [
+                { "$ref": "#/definitions/Options/WithCredentials" },
+                { "$ref": "#/definitions/Options/WithOnlyGraphs" },
+                { "$ref": "#/definitions/Options/WithIntoGraph" }
+              ]
+            }
+          }
+        }
       }
     }
   }

--- a/src/config/schema-types.ts
+++ b/src/config/schema-types.ts
@@ -6,6 +6,7 @@ export const PartShorthandStep = [
   "shell",
   "shacl",
   "infer",
+  "http-request",
 ] as const;
 export const PartShorthandTarget = [
   "file",

--- a/src/parts/download-file.ts
+++ b/src/parts/download-file.ts
@@ -1,0 +1,54 @@
+import { createWriteStream } from "fs";
+import fs from "fs/promises";
+import type { ReadableStream } from "node:stream/web";
+import pathlib from "path";
+import { Readable } from "stream";
+import { finished } from "stream/promises";
+import { IJobSourceData, type IJobStepData } from "../config/types.js";
+import {
+  JobRuntimeContext,
+  type WorkflowModuleExec,
+  type WorkflowPartStep,
+} from "../runner/types.js";
+
+/** Download a remote file to a local destination. */
+export class HttpRequestStep implements WorkflowPartStep {
+  id = () => "http-request-step";
+  names = ["steps/download-file", "steps/http-request"];
+
+  isQualified(data: IJobSourceData): boolean {
+    if (data.access.match(/^https?:\/\//)) return true;
+    return false;
+  }
+
+  exec(data: IJobStepData): WorkflowModuleExec {
+    return async (context: JobRuntimeContext) => {
+      const filename =
+        data.with?.["destination"] ?? `${context.tempdir}/${pathlib.basename(data.access)}`;
+
+      // body-file prevails over body
+      let payload: Buffer;
+
+      if (data.with?.["body"]) payload = Buffer.from(data.with["body"], "utf-8");
+      if (data.with?.["body-file"]) payload = await fs.readFile(data.with["body-file"]);
+
+      return {
+        init: async () => {
+          const response = await fetch(data.access, {
+            method: data?.with?.["method"] ?? "GET",
+            body: payload,
+            headers: data?.with?.["headers"] ?? {},
+          });
+
+          if (response.ok && response.body != null) {
+            const destination = pathlib.resolve(filename);
+            const fileStream = createWriteStream(destination, { flags: "w" });
+            await finished(
+              Readable.fromWeb(response.body as ReadableStream<Uint8Array>).pipe(fileStream)
+            );
+          }
+        },
+      };
+    };
+  }
+}

--- a/src/runner/job-supervisor.ts
+++ b/src/runner/job-supervisor.ts
@@ -43,9 +43,9 @@ async function EnterModule(
 ) {
   const moduleLocalName = data.type.split("/", 2)[1];
   // Only output last 80 chars of the Access
-  let accessLocalName = data.access;
+  let accessLocalName = data.access.trim();
   if (accessLocalName.length > 79)
-    accessLocalName = "..." + accessLocalName.replaceAll(/\s/g, " ").trim().slice(-80);
+    accessLocalName = "..." + accessLocalName.replaceAll(/\s/g, " ").trim().slice(-80).trim();
 
   const tempdir = path.join(
     TEMPDIR,

--- a/src/runner/module.ts
+++ b/src/runner/module.ts
@@ -7,6 +7,7 @@ import {
 } from "../config/types.js";
 import { AskAssertStep } from "../parts/ask-assert.js";
 import { ComunicaAutoSource } from "../parts/comunica-auto-source.js";
+import { HttpRequestStep } from "../parts/download-file.js";
 import { LocalFileSource, LocalFileTarget } from "../parts/file-local.js";
 import { InferReason } from "../parts/infer-reason.js";
 import { LacesHubSource, LacesHubTarget } from "../parts/laces-hub.js";
@@ -35,6 +36,7 @@ export const KNOWN_MODULES: RegisteredModule[] = [
   new AskAssertStep(),
   new InferReason(),
   new ShellCommandStep(),
+  new HttpRequestStep(),
   new SparqlUpdateEndpointTarget(),
   new LocalFileTarget(),
   new LacesHubSource(),


### PR DESCRIPTION
Use `step`/`http-request` to perform web requests, like:

```yaml
      - http-request: http://localhost:7200/repositories/dataset/statements
        with:
          headers:
            Accept: application/n-quads
          destination: statements.nq
```

to download all NQuads of a GraphDB instance locally running into a local file.

Also, this PR improves the YAML schema that provides autocomplete. The schema now autocompletes relevant `with` properties.